### PR TITLE
Fix: Make exePath on Linux more reliable

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -117,7 +117,7 @@ bool parseArgs(int argc, char* argv[])
     ssize_t len = readlink("/proc/self/exe", result, PATH_MAX);
     if (len != -1) {
         result[len] = 0;
-        Utils::FileSystem::setExePath(dirname(result));
+        Utils::FileSystem::setExePath(result);
     }
     delete [] result;
 #else

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -25,7 +25,6 @@
 #if defined(_WIN32)
 #include <Windows.h>
 #elif defined(__linux__)
-#include <libgen.h>
 #include <unistd.h>
 #endif
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -21,8 +21,12 @@
 #include <SDL_timer.h>
 #include <iostream>
 #include <time.h>
-#ifdef WIN32
+
+#if defined(_WIN32)
 #include <Windows.h>
+#elif defined(__linux__)
+#include <libgen.h>
+#include <unistd.h>
 #endif
 
 #include "resources/TextureData.h"
@@ -108,8 +112,17 @@ void playVideo()
 
 bool parseArgs(int argc, char* argv[])
 {
-	Utils::FileSystem::setExePath(argv[0]);
-
+#if defined(__linux__)
+    char* result = new char[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", result, PATH_MAX);
+    if (len != -1) {
+        result[len] = 0;
+        Utils::FileSystem::setExePath(dirname(result));
+    }
+    delete [] result;
+#else
+ 	Utils::FileSystem::setExePath(argv[0]);
+#endif
 	// We need to process --home before any call to Settings::getInstance(), because settings are loaded from homepath
 	for (int i = 1; i < argc; i++)
 	{


### PR DESCRIPTION
Just some very minor changes that allows package maintainers to retain the $prefix/bin and $prefix/share layout instead of bundling the resources together with the executable on Linux.