### PR TITLE
fix: cross-compatible method for setExepath

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -112,17 +112,7 @@ void playVideo()
 
 bool parseArgs(int argc, char* argv[])
 {
-#if defined(__linux__)
-    char* result = new char[PATH_MAX];
-    ssize_t len = readlink("/proc/self/exe", result, PATH_MAX);
-    if (len != -1) {
-        result[len] = 0;
-        Utils::FileSystem::setExePath(result);
-    }
-    delete [] result;
-#else
- 	Utils::FileSystem::setExePath(argv[0]);
-#endif
+	Utils::FileSystem::setExePath(argv[0]);
 	// We need to process --home before any call to Settings::getInstance(), because settings are loaded from homepath
 	for (int i = 1; i < argc; i++)
 	{

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -428,7 +428,7 @@ namespace Utils
 #if defined(_WIN32)
 			std::wstring result(path_max, 0);
 			if (GetModuleFileNameW(nullptr, &result[0], path_max) != 0) {
-				exePath = getCanonicalPath(convertFromWideString(result));
+				exePath = getCanonicalPath(Utils::String::convertFromWideString(result));
 			}
 #else
 			std::string result(path_max, 0);

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -424,11 +424,25 @@ namespace Utils
 
 		void setExePath(const std::string& _path)
 		{
-			exePath = getCanonicalPath(_path);
-
-			if (isRegularFile(exePath))
+			constexpr int path_max = 32767;
+#if defined(_WIN32)
+			std::wstring result(path_max, 0);
+			if (GetModuleFileNameW(nullptr, &result[0], path_max) != 0) {
+				exePath = getCanonicalPath(convertFromWideString(result));
+			}
+#else
+			std::string result(path_max, 0);
+			if (readlink("/proc/self/exe", &result[0], path_max) != -1) {
+				exePath = getCanonicalPath(result);
+			}
+#endif
+			// If the native implementations fail, fallback to argv[0]
+			if (exePath.empty()) {
+				exePath = getCanonicalPath(_path);
+			}
+			if (isRegularFile(exePath)) {
 				exePath = getParent(exePath);
-
+			}
 		} // setExePath
 
 		std::string getExePath()


### PR DESCRIPTION
Some code cleanup for my last PR.  This gives native methods for both Windows and Unix-like operating systems to get the correct executable path. 