### PR TITLE
fix: isDirectory returning true even on symlinks

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -921,7 +921,7 @@ namespace Utils
 		bool isDirectory(const std::string& _path)
 		{
 			auto it = FileCache::get(_path);
-			if (it != nullptr)
+			if (it != nullptr && !it->isSymLink)
 				return it->exists && it->directory;
 
 #ifdef WIN32


### PR DESCRIPTION
Fixes an issue with symlink checks.  This was causing themes to not get applied on Linux.